### PR TITLE
Refactor date handling

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "Vue.volar",
     "dbaeumer.vscode-eslint",
-    "esbenp.prettier-vscode"
+    "esbenp.prettier-vscode",
+    "vitest.explorer"
   ]
 }

--- a/functions/api/birthdays.ts
+++ b/functions/api/birthdays.ts
@@ -1,7 +1,8 @@
 import type { EventContext } from '@cloudflare/workers-types/experimental'
 import { allowedSpecies, type Birthday, type Env, type Species } from '../types'
+import { isValidISODate } from '../date'
 
-type Body = {
+export type Body = {
   code: string
   birth_date: string
   name: string
@@ -9,7 +10,7 @@ type Body = {
   species: Species
 }
 
-class ValidationError extends Error {
+export class ValidationError extends Error {
   constructor(
     public readonly fieldName: string,
     public readonly info = '',
@@ -18,14 +19,13 @@ class ValidationError extends Error {
   }
 }
 
-function parseRequestBody(body: Body): Omit<Birthday, 'id'> {
+export function parseRequestBody(body: Body): Omit<Birthday, 'id'> {
   console.log(body)
   if (!allowedSpecies.includes(body.species)) {
     throw new ValidationError('species')
   }
 
-  const parsedDate = new Date(body.birth_date)
-  if (isNaN(parsedDate.getTime())) {
+  if (!isValidISODate(body.birth_date)) {
     throw new ValidationError('birth_date')
   }
 
@@ -51,7 +51,7 @@ function parseRequestBody(body: Body): Omit<Birthday, 'id'> {
   return {
     code: body.code,
     name: body.name,
-    birth_date: parsedDate,
+    birth_date: body.birth_date,
     website: parsedWebsite,
     species: body.species,
   }
@@ -75,12 +75,12 @@ export async function onRequestPost(ctx: EventContext<Env, never, never>) {
       `INSERT INTO birthdays 
          (code, name, birth_date, website, species) 
        VALUES 
-         (?, ?, ?, ?, ?)`,
+         (?, ?, date(?), ?, ?)`,
     )
     .bind(
       birthday.code,
       birthday.name,
-      birthday.birth_date.getTime() / 1000,
+      birthday.birth_date,
       birthday.website?.toString() ?? null,
       birthday.species,
     )

--- a/functions/api/birthdays/[code]/next.ts
+++ b/functions/api/birthdays/[code]/next.ts
@@ -26,7 +26,7 @@ export async function onRequestGet(context: EventContext<Env, 'code', never>) {
   const nextBirthdayDate = birthdays[0].next_birthday
 
   return Response.json(
-    birthdays.filter((bd) => bd.next_birthday.getTime() === nextBirthdayDate.getTime()),
+    birthdays.filter((bd) => bd.next_birthday === nextBirthdayDate),
     { status: 200 },
   )
 }

--- a/functions/database.ts
+++ b/functions/database.ts
@@ -1,5 +1,6 @@
 import type { D1Database } from '@cloudflare/workers-types/experimental'
 import type { Species } from './types'
+import { calculateAgeInYears, calculateNextBirthday, formatISODate } from './date'
 
 type DbNextBirthday = {
   id: string
@@ -10,10 +11,10 @@ type DbNextBirthday = {
 }
 type NextBirthday = {
   name: string
-  birth_date: Date
+  birth_date: string
   species: Species
   website: null | string
-  next_birthday: Date
+  next_birthday: string
   age: number
 }
 
@@ -38,7 +39,7 @@ export async function getNextBirthdaysByCode(
         name,
         species,
         website,
-        DATE(birth_date, 'unixepoch') AS birth_date
+        birth_date
     FROM
         birthdays
         ${Object.entries(wheres).length ? `WHERE ${Object.keys(wheres).join(' AND ')}` : ''}
@@ -55,44 +56,19 @@ export async function getNextBirthdaysByCode(
   return birthdays.results
     .map((birthday) => {
       const birthDate = new Date(birthday.birth_date)
-      const nextBirthDay = new Date()
-      nextBirthDay.setMonth(birthDate.getMonth())
-      nextBirthDay.setDate(birthDate.getDate())
-      if (nextBirthDay < today) {
-        nextBirthDay.setFullYear(nextBirthDay.getFullYear() + 1)
-      }
-      const out = {
+      const nextBirthDay = calculateNextBirthday(birthDate, today)
+      const out: NextBirthday = {
         name: birthday.name,
-        birth_date: birthDate,
-        next_birthday: nextBirthDay,
+        birth_date: formatISODate(birthDate),
+        next_birthday: formatISODate(nextBirthDay),
         species: birthday.species,
         website: birthday.website,
         // rare off by one ofzo
-        age: calculateAge(birthDate, nextBirthDay),
+        age: calculateAgeInYears(birthDate, nextBirthDay),
       }
-      return out satisfies NextBirthday
+      return out
     })
     .sort((a, b) => {
-      const ad = a.next_birthday.getTime()
-      const bd = b.next_birthday.getTime()
-      if (ad > bd) {
-        return 1
-      }
-      if (bd > ad) {
-        return -1
-      }
-      return 0
+      return a.next_birthday.localeCompare(b.next_birthday)
     })
-}
-function calculateAge(birthDate: Date, otherDate: Date = new Date()) {
-  const years = otherDate.getFullYear() - birthDate.getFullYear()
-
-  if (
-    otherDate.getMonth() < birthDate.getMonth() ||
-    (otherDate.getMonth() == birthDate.getMonth() && otherDate.getDate() < birthDate.getDate())
-  ) {
-    return years - 1
-  }
-
-  return years
 }

--- a/functions/date.ts
+++ b/functions/date.ts
@@ -1,0 +1,34 @@
+// Formats a JavaScript Date object to a string in the format YYYY-MM-DD
+export function formatISODate(date: Date): string {
+  return date.toISOString().split('T')[0]
+}
+
+// Returns true if the given string is a valid ISO date in the format YYYY-MM-DD
+export function isValidISODate(date: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) == true && isNaN(Date.parse(date)) == false
+}
+
+// Returns the age in years between the given birth date and the other date
+export function calculateAgeInYears(birthDate: Date, otherDate: Date = new Date()): number {
+  const years = otherDate.getFullYear() - birthDate.getFullYear()
+
+  if (
+    otherDate.getMonth() < birthDate.getMonth() ||
+    (otherDate.getMonth() == birthDate.getMonth() && otherDate.getDate() < birthDate.getDate())
+  ) {
+    return years - 1
+  }
+
+  return years
+}
+
+// Returns the next birthday after the given date
+export function calculateNextBirthday(birthDate: Date, today: Date): Date {
+  const nextBirthDay = new Date()
+  nextBirthDay.setMonth(birthDate.getMonth())
+  nextBirthDay.setDate(birthDate.getDate())
+  if (nextBirthDay < today) {
+    nextBirthDay.setFullYear(nextBirthDay.getFullYear() + 1)
+  }
+  return nextBirthDay
+}

--- a/functions/types.ts
+++ b/functions/types.ts
@@ -9,7 +9,7 @@ export type Species = (typeof allowedSpecies)[number]
 export type Birthday = {
   id: number
   code: string
-  birth_date: Date
+  birth_date: string
   name: string
   website: URL | null
   species: Species

--- a/migrations/0002_insert_test_data.sql
+++ b/migrations/0002_insert_test_data.sql
@@ -1,0 +1,21 @@
+-- Migration number: 0002 	 2025-01-29T15:52:39.295Z
+
+-- Inserts test data using the group ID 'test123'
+INSERT INTO birthdays (code, name, birth_date, website, species) VALUES
+    ('test123', 'Albert Einstein', '1879-03-14', 'https://en.wikipedia.org/wiki/Albert_Einstein', 'human'),
+    ('test123', 'Nikola Tesla', '1856-07-10', 'https://en.wikipedia.org/wiki/Nikola_Tesla', 'human'),
+    ('test123', 'Marie Curie', '1867-11-07', 'https://en.wikipedia.org/wiki/Marie_Curie', 'human'),
+    ('test123', 'Bob Ross', '1942-10-29', 'https://en.wikipedia.org/wiki/Bob_Ross', 'human'),
+    ('test123', 'Bill Gates', '1955-10-28', 'https://en.wikipedia.org/wiki/Bill_Gates', 'human'),
+    
+    ('test123', 'Grumpy Cat', '2012-04-04', 'https://en.wikipedia.org/wiki/Grumpy_Cat', 'cat'),
+    ('test123', 'Maru', '2007-05-24', 'https://en.wikipedia.org/wiki/Maru_(cat)', 'cat'),
+    ('test123', 'Garfield', '1978-06-19', 'https://en.wikipedia.org/wiki/Garfield', 'cat'),
+    ('test123', 'Tom', '1940-02-10', NULL, 'cat'),
+    ('test123', 'Hello Kitty', '1974-11-01', 'https://en.wikipedia.org/wiki/Hello_Kitty', 'cat'),
+
+    ('test123', 'Laika', '1954-11-03', 'https://en.wikipedia.org/wiki/Laika', 'dog'),
+    ('test123', 'Boo', '2006-03-16', 'https://en.wikipedia.org/wiki/Boo_(dog)', 'dog'),
+    ('test123', 'Scooby-Doo', '1969-09-13', 'https://en.wikipedia.org/wiki/Scooby-Doo', 'dog'),
+    ('test123', 'Beethoven (St. Bernard)', '1992-04-03', 'https://en.wikipedia.org/wiki/Beethoven_(film)', 'dog'),
+    ('test123', 'Hachiko', '1923-11-10', 'https://en.wikipedia.org/wiki/Hachikō', 'dog');

--- a/migrations/0003_convert_unix_timestamp_to_date.sql
+++ b/migrations/0003_convert_unix_timestamp_to_date.sql
@@ -1,0 +1,4 @@
+-- Migration number: 0003 	 2025-01-29T16:47:52.305Z
+
+-- Convert the birth_date column from a Unix timestamp to a date in YYYY-MM-DD format.
+UPDATE birthdays SET birth_date = DATE(birth_date, 'unixepoch') WHERE DATE(birth_date) IS NOT birth_date;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "vue-router": "^4.3.0"
       },
       "devDependencies": {
-        "@cloudflare/workers-types": "^4.20240605.0",
+        "@cloudflare/workers-types": "^4.20250124.3",
         "@rushstack/eslint-patch": "^1.3.3",
         "@tailwindcss/forms": "^0.5.7",
         "@tsconfig/node20": "^20.1.2",
@@ -35,6 +35,7 @@
         "typescript": "~5.4.0",
         "vite": "^5.1.6",
         "vite-plugin-vue-devtools": "^7.0.18",
+        "vitest": "^2.1.8",
         "vue-tsc": "^2.0.6",
         "wrangler": "^3.60.2"
       }
@@ -771,10 +772,11 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20240605.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20240605.0.tgz",
-      "integrity": "sha512-zJw4Q6CnkaQ5JZmHRkNiSs5GfiRgUIUL8BIHPQkd2XUHZkIBv9M9yc0LKEwMYGpCFC+oSOltet6c9RjP9uQ99g==",
-      "dev": true
+      "version": "4.20250124.3",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20250124.3.tgz",
+      "integrity": "sha512-WRZ+ol4RnMroF3tc7en6w8b0MqLrmGnLr2LIhG8EWqIoy8MeYk5uhyNXMZ0WPBhwkRtDcTRwOt61xwnJrthskA==",
+      "dev": true,
+      "license": "MIT OR Apache-2.0"
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -1431,9 +1433,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -2031,6 +2034,129 @@
         "vue": "^3.2.25"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.8.tgz",
+      "integrity": "sha512-8ytZ/fFHq2g4PJVAtDX57mayemKgDR6X3Oa2Foro+EygiOJHUXhCqBAAKQYYajZpFoIfvBCF1j6R6IYRSIUFuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.8.tgz",
+      "integrity": "sha512-7guJ/47I6uqfttp33mgo6ga5Gr1VnL58rcqYKyShoRK9ebu8T5Rs6HN3s1NABiBeVTdWNrwUMcHH54uXZBN4zA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.8",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.8.tgz",
+      "integrity": "sha512-9HiSZ9zpqNLKlbIDRWOnAWqgcA7xu+8YxXSekhr0Ykab7PAYFkhkwoqVArPOtJhPmYeE2YHgKZlj3CP36z2AJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.8.tgz",
+      "integrity": "sha512-17ub8vQstRnRlIU5k50bG+QOMLHRhYPAna5tw8tYbj+jzjcspnwnwtPtiOlkuKC4+ixDPTuLZiqiWWQ2PSXHVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.8",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.8.tgz",
+      "integrity": "sha512-20T7xRFbmnkfcmgVEz+z3AU/3b0cEzZOt/zmnvZEctg64/QZbSDJEVm9fLnnlSi74KibmRsO9/Qabi+t0vCRPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.8.tgz",
+      "integrity": "sha512-5swjf2q95gXeYPevtW0BLk6H8+bPlMb4Vw/9Em4hFxDcaOxS+e0LOX4yqNxoHzMR2akEB2xfpnWUzkZokmgWDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.8.tgz",
+      "integrity": "sha512-dwSoui6djdwbfFmIgbIjX2ZhIoG7Ex/+xpxyiEgIGzjliY8xGkcpITKTlp6B4MgtGkF2ilvm97cPM96XZaAgcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.8",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@volar/language-core": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.3.0.tgz",
@@ -2453,6 +2579,16 @@
         "printable-characters": "^1.0.42"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.4.19",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
@@ -2588,6 +2724,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -2648,6 +2794,23 @@
         "tslib": "^2.2.0"
       }
     },
+    "node_modules/chai": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.2.tgz",
+      "integrity": "sha512-aGtmf24DW6MLHHG5gCx4zaI3uBq3KRtxeVs0DjFH6Z0rDNbsvTxFASFvdj79pxjxZ8/5u3PIiN3IwEIQkiiuPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2662,6 +2825,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+      "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/chokidar": {
@@ -2807,12 +2980,13 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.5.tgz",
-      "integrity": "sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -2821,6 +2995,16 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/deep-is": {
@@ -2948,6 +3132,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.6.0.tgz",
+      "integrity": "sha512-qqnD1yMU6tk/jnaMosogGySTZP8YtUgAffA9nMN+E/rjxcfRQ6IEk7IiozUjgxKoFHBGjTLnrHB/YC45r/59EQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.20.2",
@@ -3274,6 +3465,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.1.0.tgz",
+      "integrity": "sha512-bFi65yM+xZgk+u/KRIpekdSYkTB5W1pEf0Lt8Q8Msh7b+eQ7LXVtIB1Bkm4fvclDEL1b2CZkMhv2mOeF8tMdkA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4037,6 +4238,13 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/loupe": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.3.tgz",
+      "integrity": "sha512-kkIp7XSkP78ZxJEsSxW3712C6teJVoeHHwgo9zJ380de7IYyJ2ISlxojcH2pC5OFLewESmnRi/+XCDIEEVyoug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -4047,11 +4255,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.10",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.10.tgz",
-      "integrity": "sha512-iIRwTIf0QKV3UAnYK4PU8uiEc4SRh5jX0mwpIwETPpHdhVM4f53RSwS/vXvN1JhGX+Cs7B8qIq3d6AH49O5fAQ==",
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.4.15"
+        "@jridgewell/sourcemap-codec": "^1.5.0"
       }
     },
     "node_modules/memorystream": {
@@ -4190,10 +4399,11 @@
       }
     },
     "node_modules/ms": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/muggle-string": {
       "version": "0.4.1",
@@ -4571,6 +4781,16 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
       "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
       "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+      "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
     },
     "node_modules/perfect-debounce": {
       "version": "1.0.0",
@@ -5195,6 +5415,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5263,6 +5490,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/stacktracey": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.1.8.tgz",
@@ -5272,6 +5506,13 @@
         "as-table": "^1.0.36",
         "get-source": "^2.0.12"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.8.0.tgz",
+      "integrity": "sha512-Bc3YwwCB+OzldMxOXJIIvC6cPRWr/LxOp48CdQTOkPyk/t4JWWJbrilwBd7RJzKV8QW7tJkcgAmeuLLJugl5/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stoppable": {
       "version": "1.1.0",
@@ -5566,6 +5807,50 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.0.2.tgz",
+      "integrity": "sha512-al6n+QEANGFOMf/dmUMsuS5/r9B06uwlyNjZZql/zv8J7ybHCgoihBNORZCY2mzUuAnomQa2JdhyHKzZxPCrFA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/to-fast-properties": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -5649,6 +5934,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.5.tgz",
       "integrity": "sha512-vcI4UpRgg81oIRUFwR0WSIHKt11nJ7SAVlYNIu+QpqeyXP+gpQJy/Z4+F0aGxSE4MqwjyXvW/TzgkLAx2AGHwQ==",
       "devOptional": true,
+      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5817,6 +6103,29 @@
         "vite": "^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0"
       }
     },
+    "node_modules/vite-node": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.8.tgz",
+      "integrity": "sha512-uPAwSr57kYjAUux+8E2j0q0Fxpn8M9VoyfGiRI8Kfktz9NcYMCenwY5RnZxnF1WTu3TGiYipirIzacLL3VVGFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/vite-plugin-inspect": {
       "version": "0.8.4",
       "resolved": "https://registry.npmjs.org/vite-plugin-inspect/-/vite-plugin-inspect-0.8.4.tgz",
@@ -5887,6 +6196,72 @@
       },
       "peerDependencies": {
         "vite": "^3.0.0-0 || ^4.0.0-0 || ^5.0.0-0"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.8.tgz",
+      "integrity": "sha512-1vBKTZskHw/aosXqQUlVWWlGUxSJR8YtiyZDJAFeW2kPAeX6S3Sool0mjspO+kXLuxVWlEDDowBAeqeAQefqLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.8",
+        "@vitest/mocker": "2.1.8",
+        "@vitest/pretty-format": "^2.1.8",
+        "@vitest/runner": "2.1.8",
+        "@vitest/snapshot": "2.1.8",
+        "@vitest/spy": "2.1.8",
+        "@vitest/utils": "2.1.8",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.8",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.8",
+        "@vitest/ui": "2.1.8",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
       }
     },
     "node_modules/vscode-uri": {
@@ -5993,6 +6368,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "test": "vitest",
     "build": "run-p type-check \"build-only {@}\" --",
     "preview": "npm run build && wrangler pages dev ./dist",
     "build-only": "vite build",
@@ -21,7 +22,7 @@
     "vue-router": "^4.3.0"
   },
   "devDependencies": {
-    "@cloudflare/workers-types": "^4.20240605.0",
+    "@cloudflare/workers-types": "^4.20250124.3",
     "@rushstack/eslint-patch": "^1.3.3",
     "@tailwindcss/forms": "^0.5.7",
     "@tsconfig/node20": "^20.1.2",
@@ -41,6 +42,7 @@
     "typescript": "~5.4.0",
     "vite": "^5.1.6",
     "vite-plugin-vue-devtools": "^7.0.18",
+    "vitest": "^2.1.8",
     "vue-tsc": "^2.0.6",
     "wrangler": "^3.60.2"
   }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -4,7 +4,6 @@ import {
   type RawNextBirthday,
   type Species,
   intoBirthday,
-  type RawBirthday,
 } from './birthday'
 
 export const fetchNextBirthday = async (

--- a/src/views/AddBirthdayForm.vue
+++ b/src/views/AddBirthdayForm.vue
@@ -91,9 +91,14 @@ const errors = reactive({
   website: '',
 })
 
+// TODO: IDK how to share this function with the backend
+function isValidISODate(date: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}$/.test(date) == true && isNaN(Date.parse(date)) == false
+}
+
 const validateForm = () => {
   errors.name = form.name ? '' : 'Dit veld is verplicht'
-  errors.birth_date = !isNaN(Date.parse(form.birth_date)) ? '' : 'Ongeldige datum'
+  errors.birth_date = isValidISODate(form.birth_date) ? '' : 'Ongeldige datum'
   errors.code = form.code.length >= MIN_CODE_LENGTH ? '' : `Minimaal ${MIN_CODE_LENGTH} karakters`
   if (form.website) {
     try {

--- a/test/birthdays.test.ts
+++ b/test/birthdays.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { parseRequestBody, ValidationError } from '../functions/api/birthdays'
+
+describe('parseRequestBody', () => {
+  it('parses a valid request body', () => {
+    expect(parseRequestBody({
+      code: 'test1234',
+      name: 'Alice',
+      birth_date: '2000-01-01',
+      website: 'https://lijstje.nl/alice',
+      species: 'human',
+    })).toEqual({
+      code: 'test1234',
+      name: 'Alice',
+      birth_date: '2000-01-01',
+      website: new URL('https://lijstje.nl/alice'),
+      species: 'human',
+    })
+  })
+
+  it('throws a ValidationError for an invalid request body', () => {
+    expect(() => parseRequestBody({
+      code: 'test1234',
+      name: 'Alice',
+      birth_date: '01-2000',
+      website: 'https://lijstje.nl/alice',
+      species: 'human',
+    })).toThrowError(new ValidationError('birth_date'))
+
+    expect(() => parseRequestBody({
+      code: 'test1234',
+      name: 'Alice',
+      birth_date: '2025-02-32',
+      website: 'https://lijstje.nl/alice',
+      species: 'human',
+    })).toThrowError(new ValidationError('birth_date'))
+
+    expect(() => parseRequestBody({
+      code: 'test1234',
+      name: 'Alice',
+      birth_date: '2000-10-01',
+      website: 'https://pauperhosting.nl/',
+      species: 'human',
+    })).toThrowError(new ValidationError('website'))
+  })
+})

--- a/test/date.test.ts
+++ b/test/date.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest';
+import { isValidISODate, formatISODate, calculateAgeInYears } from '../functions/date';
+
+describe('isValidISODate', () => {
+  it('returns true for a valid date', () => {
+    expect(isValidISODate('1992-01-01')).toBe(true);
+  });
+
+  it('returns false for an invalid date', () => {
+    expect(isValidISODate('1992-01-32')).toBe(false);
+    expect(isValidISODate('01-01-1992')).toBe(false);
+  });
+});
+
+describe('formatISODate', () => {
+  it('formats a date as ISO', () => {
+    expect(formatISODate(new Date('1992-01-01'))).toBe('1992-01-01');
+    expect(formatISODate(new Date('1992-01-01T12:34:56Z'))).toBe('1992-01-01');
+  });
+});
+
+describe('calculateAgeInYears', () => {
+    it('calculates the age in years', () => {
+        expect(calculateAgeInYears(new Date('1992-01-01'), new Date('2020-01-01'))).toBe(28);
+        expect(calculateAgeInYears(new Date('1992-01-01'), new Date('2020-12-31'))).toBe(28);
+        expect(calculateAgeInYears(new Date('1992-01-01'), new Date('2021-01-01'))).toBe(29);
+    });
+});

--- a/tsconfig.functions.json
+++ b/tsconfig.functions.json
@@ -8,5 +8,5 @@
     "lib": ["esnext"],
     "types": ["@cloudflare/workers-types"]
   },
-  "include": ["functions/**"]
+  "include": ["functions/**/*"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*'],
+  },
+})

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -3,8 +3,8 @@ pages_build_output_dir="./dist"
 compatibility_date = "2024-06-05"
 
 [[d1_databases]]
-binding = "DB" # available in your Worker on env.DB
+binding = "DB" # available in your Worker on env.DB. Should match preview_database_id.
 database_name = "volgendeverjaardag"
-database_id = "ab4e6079-33f4-4614-be5c-574b49b7123f"
+database_id = "ab4e6079-33f4-4614-be5c-574b49b7123f" # wrangler d1 info YOUR_DATABASE_NAME
 migrations_dir = "./migrations"
-
+preview_database_id = "DB" # Required for Pages local development


### PR DESCRIPTION
This refactors the handling of dates so that instead of (UNIX) timestamps, only ISO YYYY-MM-DD dates (without any associated time or timezone information) are being stored in the database and passed between the backend and frontend.

List of changes:
* Adds a database migration that converts all the birthdays to YYYY-MM-DD dates using the SQLite `date()` function.
* Updates the API between frontend and backend to use YYYY-MM-DD strings for dates. They are only formatted to human-readable dates in the frontend just before being displayed.
* Moved backend date logic into a separate 'date.ts' file
* Adds some unit tests for the backend date logic using Vitest.